### PR TITLE
Ensure +N weekdays return a weekday on PHP 5.4

### DIFF
--- a/src/BusinessDays.php
+++ b/src/BusinessDays.php
@@ -9,7 +9,7 @@ use DateTime;
  * @copyright 2015, Clippings Ltd.
  * @license   http://spdx.org/licenses/BSD-3-Clause
  */
-class BusinessDays extends Days
+class BusinessDays extends WeekDays
 {
     private $holidays = null;
 
@@ -40,8 +40,7 @@ class BusinessDays extends Days
             $start = clone $start;
         }
 
-        $end = clone $start;
-        $end->modify("+ {$this->getDays()} weekdays");
+        $end = parent::toDateTime($start);
 
         if ($this->holidays) {
             $span = new DateTimeSpan($start, $end);

--- a/src/Holidays.php
+++ b/src/Holidays.php
@@ -39,11 +39,14 @@ class Holidays
     {
         $current = clone $span->getFrom();
 
-        while ($current->format('d m Y') <= $span->getTo()->format('d m Y')) {
-            $this->add($current);
+        while ($current <= $span->getTo()) {
+            // Check if it's not during the weekend
+            if (6 > (int) $current->format('N')) {
+                $this->add($current);
+            }
 
             $current = clone $current;
-            $current->modify(' + 1 weekday');
+            $current = WeekDays::ensureWeekdays($current->modify('+1 weekday'));
         }
 
         return $this;
@@ -72,7 +75,7 @@ class Holidays
 
         foreach ($this->days as $holiday) {
             if ($holiday > $span->getFrom() and $holiday < $to) {
-                $to->modify('+ 1 weekday');
+                $to = WeekDays::ensureWeekdays($to->modify('+1 weekday'));
             }
         }
 

--- a/src/WeekDays.php
+++ b/src/WeekDays.php
@@ -19,11 +19,34 @@ class WeekDays extends Days
             $start = clone $start;
         }
 
-        return $start->modify("+ {$this->getDays()} weekdays");
+        $end = $start->modify("+ {$this->getDays()} weekdays");
+
+        return WeekDays::ensureWeekdays($end);
     }
 
     public function humanize()
     {
         return "{$this->getDays()} week days";
+    }
+
+    /**
+     * Workaround for PHP 5.4 bug https://bugs.php.net/bug.php?id=63521
+     * Ensure weekdays are correctly used despite the bug in PHP 5.4
+     * which might result in Sunday instead of Friday.
+     *
+     * @param  DateTime $date
+     * @return DateTime
+     */
+    public static function ensureWeekdays(DateTime $date)
+    {
+        $weekDay = (int) $date->format('N');
+
+        if (7 === $weekDay) {
+            $date = $date->modify('-2 days');
+        } elseif (6 === $weekDay) {
+            $date = $date->modify('-1 day');
+        }
+
+        return $date;
     }
 }

--- a/tests/src/BusinessDaysTest.php
+++ b/tests/src/BusinessDaysTest.php
@@ -52,6 +52,13 @@ class BusinessDaysTest extends PHPUnit_Framework_TestCase
                 null,
                 new DateTime('now + 40 weekdays')
             ],
+            // Test workaround for PHP 5.4 bug with weekdays and Sundays
+            [
+                5,
+                null,
+                new DateTime('2015-06-20'),
+                new DateTime('2015-06-26'),
+            ],
         ];
     }
 

--- a/tests/src/HolidaysTest.php
+++ b/tests/src/HolidaysTest.php
@@ -54,6 +54,29 @@ class HolidaysTest extends PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expected, $holidays->getDays());
+
+        $holidays = new Holidays();
+        $span = new DateTimeSpan(new DateTime('2015-06-20'), new DateTime('2015-06-23'));
+        $holidays->addDateTimeSpan($span);
+
+        $expected = [
+            new DateTime('2015-06-22'),
+            new DateTime('2015-06-23'),
+        ];
+
+        $this->assertEquals($expected, $holidays->getDays());
+
+        $holidays = new Holidays();
+        $span = new DateTimeSpan(new DateTime('2015-06-19'), new DateTime('2015-06-23'));
+        $holidays->addDateTimeSpan($span);
+
+        $expected = [
+            new DateTime('2015-06-19'),
+            new DateTime('2015-06-22'),
+            new DateTime('2015-06-23'),
+        ];
+
+        $this->assertEquals($expected, $holidays->getDays());
     }
 
     /**
@@ -61,6 +84,22 @@ class HolidaysTest extends PHPUnit_Framework_TestCase
      */
     public function testExtendDateTimeSpan()
     {
+        $holidays = new Holidays([
+            new DateTime('2015-06-17'),
+            new DateTime('2015-06-18'),
+            new DateTime('2015-06-19'),
+            new DateTime('2015-06-22'),
+            new DateTime('2015-06-23'),
+        ]);
+
+        $span = new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-30'));
+
+        $result = $holidays->extendDateTimeSpan($span);
+
+        $expected = new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-07-07'));
+
+        $this->assertEquals($expected, $result);
+
         $holidays = new Holidays([
             new DateTime('2015-06-17'),
             new DateTime('2015-06-18'),

--- a/tests/src/WeekDaysTest.php
+++ b/tests/src/WeekDaysTest.php
@@ -17,6 +17,7 @@ class WeekDaysTest extends PHPUnit_Framework_TestCase
             [5, new DateTime('2015-02-02'), new DateTime('2015-02-09')],
             [12, new DateTime('2015-03-01'), new DateTime('2015-03-17')],
             [40, null, new DateTime('now + 40 weekdays')],
+            [5, new DateTime('2015-06-20'), new DateTime('2015-06-26')],
         ];
     }
 
@@ -47,5 +48,25 @@ class WeekDaysTest extends PHPUnit_Framework_TestCase
     public function testHumanize($input, $result)
     {
         $this->assertSame($result, $input->humanize());
+    }
+
+    public function dataEnsureWeekdays()
+    {
+        return [
+            [new DateTime('2015-06-21'), new DateTime('2015-06-19')],
+            [new DateTime('2015-06-20'), new DateTime('2015-06-19')],
+            [(new DateTime('2015-06-19'))->modify('+5 weekdays'), new DateTime('2015-06-26')],
+            [(new DateTime('2015-06-20'))->modify('+5 weekdays'), new DateTime('2015-06-26')],
+            [(new DateTime('2015-06-21'))->modify('+5 weekdays'), new DateTime('2015-06-26')],
+        ];
+    }
+
+    /**
+     * @covers ::ensureWeekdays
+     * @dataProvider dataEnsureWeekdays
+     */
+    public function testEnsureWeekdays(DateTime $date, DateTime $expectedDate)
+    {
+        $this->assertEquals($expectedDate, WeekDays::ensureWeekdays($date));
     }
 }


### PR DESCRIPTION
This is a workaround for this bug in PHP 5.4: https://bugs.php.net/bug.php?id=63521

It results in problems when trying to add a certain number of weekdays to a date which is Friday, Saturday or Sunday.
The resulting date is always Sunday when it should be Friday.

But why patching this bug in the library when it's an actual bug in the PHP language itself?
Well, it was fixed in PHP 5.5, but it would never get fixed in PHP 5.4. And since we're relying on the library anyway it is better to always have reliable results instead of having wrong dates or remembering to fix it every time in application-level code.

---

This also fixes a problem with `Holidays` which I encountered while I was testing my changes. If you previously added days to the `Holidays` object and it started with a weekend day, it will always add it, even though it shouldn't.
