### PR TITLE
Require PHP 5.5 as a minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "role": "Author"
         }
     ],
+    "require": {
+        "php": ">=5.5"
+    },
     "autoload": {
         "psr-4": {
             "CL\\DateUtils\\": "src/"


### PR DESCRIPTION
Only PHP >= 5.5 has a correct behavior of working days.
