### PR TITLE
Fixed holiday expand logic

### DIFF
--- a/src/Holidays.php
+++ b/src/Holidays.php
@@ -100,20 +100,56 @@ class Holidays implements Countable
     }
 
     /**
-     * @param  DateTime $from
-     * @param  DateTime $date
-     * @return DateTime
+     * @param  DateTimeSpan $span
+     * @param  DateTime $start_date
+     * @return DateTimeSpan
      */
-    public function extendDateTimeSpan(DateTimeSpan $span)
+    public function extendDateTimeSpan(DateTimeSpan $span, DateTime $start_date = null)
     {
+        $from = clone $span->getFrom();
         $to = clone $span->getTo();
 
         foreach ($this->dates as $holiday) {
-            if ($holiday > $span->getFrom() and $holiday < $to) {
+            if ($start_date and $holiday < $start_date) {
+                continue;
+            }
+
+            if ($holiday <= $from) {
+                $from->modify('+1 day');
+            }
+
+            if ($holiday <= $to) {
                 $to->modify('+1 day');
             }
         }
 
-        return new DateTimeSpan($span->getFrom(), $to);
+        return new DateTimeSpan($from, $to);
+    }
+
+    /**
+     * @param  DateTimeSpan $span
+     * @param  DateTime $start_date
+     * @return DateTimeSpan
+     */
+    public function extendBusinessDateTimeSpan(DateTimeSpan $span, DateTime $start_date = null)
+    {
+        $from = clone $span->getFrom();
+        $to = clone $span->getTo();
+
+        foreach ($this->dates as $holiday) {
+            if (($start_date and $holiday < $start_date) or 5 < $holiday->format('N')) {
+                continue;
+            }
+
+            if ($holiday <= $from) {
+                $from->modify('+1 weekday');
+            }
+
+            if ($holiday <= $to) {
+                $to->modify('+1 weekday');
+            }
+        }
+
+        return new DateTimeSpan($from, $to);
     }
 }

--- a/tests/src/HolidaysTest.php
+++ b/tests/src/HolidaysTest.php
@@ -115,10 +115,42 @@ class HolidaysTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $holidays->getDates());
     }
 
+    public function dataExtendDateTimeSpan()
+    {
+        return [
+            [
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-30')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-07-07')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-17'), new DateTime('2015-06-30')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-24'), new DateTime('2015-07-07')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-19'), new DateTime('2015-06-22')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-26'), new DateTime('2015-06-29')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-22')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-29')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-19'), new DateTime('2015-06-22')),
+                new DateTime('2015-06-18'),
+                new DateTimeSpan(new DateTime('2015-06-25'), new DateTime('2015-06-28')),
+            ]
+        ];
+    }
+
     /**
      * @covers ::extendDateTimeSpan
+     * @dataProvider dataExtendDateTimeSpan
      */
-    public function testExtendDateTimeSpan()
+    public function testExtendDateTimeSpan($span, $start_date, $expected)
     {
         $holidays = new Holidays([
             new DateTime('2015-06-17'),
@@ -130,29 +162,57 @@ class HolidaysTest extends PHPUnit_Framework_TestCase
             new DateTime('2015-06-23'),
         ]);
 
-        $span = new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-30'));
-
-        $result = $holidays->extendDateTimeSpan($span);
-
-        $expected = new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-07-07'));
+        $result = $holidays->extendDateTimeSpan($span, $start_date);
 
         $this->assertEquals($expected, $result);
+    }
 
+    public function dataExtendBusinessDateTimeSpan()
+    {
+        return [
+            [
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-30')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-07-03')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-17'), new DateTime('2015-06-30')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-22'), new DateTime('2015-07-03')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-19'), new DateTime('2015-06-22')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-24'), new DateTime('2015-06-25')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-22')),
+                null,
+                new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-25')),
+            ],
+            [
+                new DateTimeSpan(new DateTime('2015-06-19'), new DateTime('2015-06-22')),
+                new DateTime('2015-06-18'),
+                new DateTimeSpan(new DateTime('2015-06-23'), new DateTime('2015-06-24')),
+            ]
+        ];
+    }
+
+    /**
+     * @covers ::extendBusinessDateTimeSpan
+     * @dataProvider dataExtendBusinessDateTimeSpan
+     */
+    public function testExtendBusinessDateTimeSpan($span, $start_date, $expected)
+    {
         $holidays = new Holidays([
             new DateTime('2015-06-17'),
             new DateTime('2015-06-18'),
             new DateTime('2015-06-19'),
             new DateTime('2015-06-20'),
             new DateTime('2015-06-21'),
-            new DateTime('2015-06-22'),
-            new DateTime('2015-06-23'),
         ]);
 
-        $span = new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-06-30'));
-
-        $result = $holidays->extendDateTimeSpan($span);
-
-        $expected = new DateTimeSpan(new DateTime('2015-06-12'), new DateTime('2015-07-07'));
+        $result = $holidays->extendBusinessDateTimeSpan($span, $start_date);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
 Fixed logic for holidays starting before the span provided, added optional start_date to from which the holiday should be measured.

Added expand logic for business days.
